### PR TITLE
Fix deprecated proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ui-components",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Handy UI components for React Native apps",
   "repository": "https://github.com/sussol/react-native-ui-components.git",
   "author": "Sustainable Solutions (NZ) Ltd.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ui-components",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Handy UI components for React Native apps",
   "repository": "https://github.com/sussol/react-native-ui-components.git",
   "author": "Sustainable Solutions (NZ) Ltd.",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "react-native-vector-icons": "*",
-    "react-native": "*",
+    "react-native": ">= 44.0.0",
     "react": "*",
     "prop-types": "*",
     "realm": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ui-components",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Handy UI components for React Native apps",
   "repository": "https://github.com/sussol/react-native-ui-components.git",
   "author": "Sustainable Solutions (NZ) Ltd.",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "react-native-vector-icons": "*",
-    "react-native": ">= 44.0.0",
+    "react-native": ">= 0.44.0",
     "react": "*",
     "prop-types": "*",
     "realm": "*"

--- a/src/Button.js
+++ b/src/Button.js
@@ -5,6 +5,7 @@ import {
   Text,
   TouchableHighlight,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 export function Button(props) {
@@ -30,7 +31,7 @@ export function Button(props) {
 }
 
 Button.propTypes = {
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
   onPress: PropTypes.func,
   text: PropTypes.string,

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 
 export const getProgressPercentage = (progress, total) =>
@@ -19,9 +20,9 @@ export const ProgressBar = ({ progress, total, isComplete }) => (
 );
 
 ProgressBar.propTypes = {
-  total: React.PropTypes.number,
-  progress: React.PropTypes.number,
-  isComplete: React.PropTypes.bool,
+  total: PropTypes.number,
+  progress: PropTypes.number,
+  isComplete: PropTypes.bool,
 };
 
 ProgressBar.defaultProps = {


### PR DESCRIPTION
View.PropTypes got deprecated, this will crash APKs some where after RN@0.44.0 (but work fine in debug annoyingly).

Also PropTypes got remove from React into it's own 'prop-types' npm package quite a while ago. This would RSoD.

  